### PR TITLE
Fix array out-of-bounds error

### DIFF
--- a/src/leaflet-sidepanel.js
+++ b/src/leaflet-sidepanel.js
@@ -57,7 +57,7 @@ L.Control.SidePanel = L.Control.extend({
 
 			if (typeof this.options.startTab === 'number' && (this.options.startTab - 1) === tabIndex) {
 				startTab = tabLink;
-				startContent = tabsContents[tabIndex - 1];
+				startContent = tabsContents[tabIndex];
 			}
 
 			if (typeof this.options.startTab === 'string' && this.options.startTab === tabLink.dataset.tabLink) {


### PR DESCRIPTION
if the `startTab` option has a value of 1, an error occurs because `startContent` tries accessing index `-1` of `tabsContents` because there is a bug that negates `tabIndex` instead of the `this.options.startTab` value

```
if (typeof this.options.startTab === 'number' && (this.options.startTab - 1) === tabIndex) {
  startTab = tabLink;
  startContent = tabsContents[tabIndex - 1];
}
```